### PR TITLE
card editor: move padding inside textviews to avoid ugly clipping

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -14,14 +14,9 @@
   color: inherit;
 }
 
-.scrolled-window undershoot.top {
-  box-shadow: inset 0 1px alpha(@shade_color, .75);
-  background: linear-gradient(to bottom, alpha(@shade_color, .75), transparent 4px);
-}
-
-.scrolled-window undershoot.bottom {
-  box-shadow: inset 0 -1px alpha(@shade_color, .75);
-  background: linear-gradient(to top, alpha(@shade_color, .75), transparent 4px);
+.scrolled-window undershoot {
+  background: none;
+  box-shadow: none;
 }
 
 .card-text {

--- a/data/ui/card_edit.blp
+++ b/data/ui/card_edit.blp
@@ -57,6 +57,8 @@ template $CardEdit : Gtk.Box {
                 label: _("Insert the front side here...");
                 halign: start;
                 valign: start;
+                margin-top: 12;
+                margin-start: 12;
                 sensitive: false;
               }
             }
@@ -96,6 +98,8 @@ template $CardEdit : Gtk.Box {
                 label: _("Insert the back side here...");
                 halign: start;
                 valign: start;
+                margin-top: 12;
+                margin-start: 12;
                 sensitive: false;
               }
             }

--- a/data/ui/card_edit.blp
+++ b/data/ui/card_edit.blp
@@ -36,15 +36,16 @@ template $CardEdit : Gtk.Box {
           styles ["card", "text-box"]
 
           Gtk.ScrolledWindow {
-            margin-top: 12;
-            margin-bottom: 12;
-            margin-start: 12;
-            margin-end: 12;
 
             styles ["scrolled-window"]
 
             Gtk.Overlay {
               child: Gtk.TextView front_side_view {
+                top-margin: 12;
+                bottom-margin: 12;
+                left-margin: 12;
+                right-margin: 12;
+
                 wrap-mode: word_char;
                 hexpand: true;
                 vexpand: true;
@@ -74,15 +75,16 @@ template $CardEdit : Gtk.Box {
           styles ["card", "text-box"]
 
           Gtk.ScrolledWindow {
-            margin-top: 12;
-            margin-bottom: 12;
-            margin-start: 12;
-            margin-end: 12;
 
             styles ["scrolled-window"]
 
             Gtk.Overlay {
               child: Gtk.TextView back_side_view {
+                top-margin: 12;
+                bottom-margin: 12;
+                left-margin: 12;
+                right-margin: 12;
+
                 wrap-mode: word_char;
                 hexpand: true;
                 vexpand: true;

--- a/data/ui/card_new_view.blp
+++ b/data/ui/card_new_view.blp
@@ -36,15 +36,16 @@ template $CardNewView : Gtk.Box {
           styles ["card", "text-box"]
 
           Gtk.ScrolledWindow {
-            margin-top: 12;
-            margin-bottom: 12;
-            margin-start: 12;
-            margin-end: 12;
 
             styles ["scrolled-window"]
 
             Gtk.Overlay {
               child: Gtk.TextView front_side_view {
+                top-margin: 12;
+                bottom-margin: 12;
+                left-margin: 12;
+                right-margin: 12;
+
                 wrap-mode: word_char;
                 hexpand: true;
                 vexpand: true;
@@ -74,15 +75,16 @@ template $CardNewView : Gtk.Box {
           styles ["card", "text-box"]
 
           Gtk.ScrolledWindow {
-            margin-top: 12;
-            margin-bottom: 12;
-            margin-start: 12;
-            margin-end: 12;
 
             styles ["scrolled-window"]
 
             Gtk.Overlay {
               child: Gtk.TextView back_side_view {
+                top-margin: 12;
+                bottom-margin: 12;
+                left-margin: 12;
+                right-margin: 12;
+
                 wrap-mode: word_char;
                 hexpand: true;
                 vexpand: true;

--- a/data/ui/card_new_view.blp
+++ b/data/ui/card_new_view.blp
@@ -57,6 +57,8 @@ template $CardNewView : Gtk.Box {
                 label: _("Insert the front side here...");
                 halign: start;
                 valign: start;
+                margin-top: 12;
+                margin-start: 12;
                 sensitive: false;
               }
             }
@@ -96,6 +98,8 @@ template $CardNewView : Gtk.Box {
                 label: _("Insert the back side here...");
                 halign: start;
                 valign: start;
+                margin-top: 12;
+                margin-start: 12;
                 sensitive: false;
               }
             }


### PR DESCRIPTION
Allow content to go all the way to the edge of the container, and drop the undershoot shadow:

![image](https://github.com/user-attachments/assets/c0dd3bd9-74e8-4db0-a846-b69acc20eded)

Fixes #33
