### PR TITLE
build: update blueprint-compiler version

### DIFF
--- a/im.bernard.Memorado.json
+++ b/im.bernard.Memorado.json
@@ -29,7 +29,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.10.0"
+                    "tag": "v0.16.0"
                 }
         	]
         },


### PR DESCRIPTION
Updates the blueprint-compiler to the latest version, fixing a build error with running an outdated blueprint-compiler version.