### PR TITLE
window: use correct Gio.copy_async parameters

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -610,9 +610,7 @@ class Window(Adw.ApplicationWindow):
             GLib.PRIORITY_DEFAULT,
             None,
             None,
-            None,
-            self.on_replace_contents,
-            None
+            self.on_copy_cb,
             )
 
         toast = Adw.Toast(
@@ -622,7 +620,7 @@ class Window(Adw.ApplicationWindow):
 
         self.toast_overlay.add_toast(toast);
 
-    def on_replace_contents(self, file, result, unused):
+    def on_copy_cb(self, file, result):
         file.copy_finish(result)
 
 


### PR DESCRIPTION
Removes the additional parameters to `Gio.copy_async`, allowing the file to be correctly saved when exporting.

Closes: https://github.com/wbernard/Memorado/issues/78