### PR TITLE
import apkg anki files

### DIFF
--- a/im.bernard.Memorado.json
+++ b/im.bernard.Memorado.json
@@ -29,7 +29,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.10.0"
+                    "tag": "v0.16.0"
                 }
         	]
         },

--- a/src/window.py
+++ b/src/window.py
@@ -162,6 +162,20 @@ class Window(Adw.ApplicationWindow):
         self.export_dialog = Gtk.FileDialog(title="Export as File", initial_name="database.db")
         self.import_dialog = Gtk.FileDialog(title="Import Database")
 
+        file_filters = Gio.ListStore.new(Gtk.FileFilter)
+        # file filter for sqlite databases, e.g. `.db` or `.anki2`
+        sql_file_filter = Gtk.FileFilter.new()
+        sql_file_filter.set_name(_("Supported files"))
+        sql_file_filter.add_mime_type("application/vnd.sqlite3")
+        file_filters.append(sql_file_filter)
+
+        all_file_filter = Gtk.FileFilter.new()
+        all_file_filter.set_name(_("All files"))
+        all_file_filter.add_pattern("*")
+        file_filters.append(all_file_filter)
+
+        self.import_dialog.set_filters(file_filters)
+
     def tabel_erstel(self, dateiname):
         # Pfad zur Datenbank
         data_dir = (

--- a/src/window.py
+++ b/src/window.py
@@ -159,8 +159,8 @@ class Window(Adw.ApplicationWindow):
             self.navigation_view.replace_with_tags(["list_view"])
 
 
-        self.export_dialog = Gtk.FileDialog(title="Export as File", initial_name="database.db")
-        self.import_dialog = Gtk.FileDialog(title="Import Database")
+        self.export_dialog = Gtk.FileDialog(title=_("Export as File"), initial_name="database.db")
+        self.import_dialog = Gtk.FileDialog(title=_("Import Database"))
 
         file_filters = Gio.ListStore.new(Gtk.FileFilter)
         # file filter for sqlite databases, e.g. `.db` or `.anki2`

--- a/src/window.py
+++ b/src/window.py
@@ -5,6 +5,7 @@ import json
 import uuid
 import sqlite3
 import random
+import zipfile
 
 
 from gi.repository import Adw, Gtk, Gio, GObject, GLib
@@ -167,6 +168,7 @@ class Window(Adw.ApplicationWindow):
         sql_file_filter = Gtk.FileFilter.new()
         sql_file_filter.set_name(_("Supported files"))
         sql_file_filter.add_mime_type("application/vnd.sqlite3")
+        sql_file_filter.add_pattern("*.apkg")
         file_filters.append(sql_file_filter)
 
         all_file_filter = Gtk.FileFilter.new()
@@ -649,9 +651,13 @@ class Window(Adw.ApplicationWindow):
 
         filename, file_extension = os.path.splitext(file)
         if file_extension == ".db":
-            self.import_db_file(file)
+            self.import_db_file(file.get_path())
         elif file_extension == ".anki2":
-            self.import_anki2_file(file)
+            self.import_anki2_file(file.get_path())
+        elif file_extension == ".apkg":
+            with zipfile.ZipFile(file, 'r') as archive:
+                anki_file = archive.extract("collection.anki2", pwd=GLib.get_tmp_dir())
+                self.import_anki2_file(anki_file)
         else:
             print("Extension", file_extension, "not supported")
 
@@ -730,7 +736,7 @@ class Window(Adw.ApplicationWindow):
 
         self.toast_overlay.add_toast(toast);
 
-    def import_anki2_file(self, file):
+    def import_anki2_file(self, file_path):
 
         imported_deck_name = "Imported Deck"
         imported_deck_id = '%030x' % random.randrange(16**32)
@@ -739,7 +745,7 @@ class Window(Adw.ApplicationWindow):
         imported_decks = [[imported_deck_id,imported_deck_name,imported_deck_icon]]
 
         ## Filter imported database content
-        conn = sqlite3.connect(file.get_path())
+        conn = sqlite3.connect(file_path)
         c = conn.cursor()
 
         imported_cards = []


### PR DESCRIPTION
Anki files can be exported as [Deck packages `.apkg`](https://docs.ankiweb.net/exporting.html#deck-apkg). These contain the anki2 file itself, alongside all the media included in the deck. As they are renamed zip files, we can simply extract the `collection.anki2` and import it normally.

Based on https://github.com/wbernard/Memorado/pull/85.